### PR TITLE
Add a check to see if Jenkins is clobbering tags

### DIFF
--- a/ldflags.sh
+++ b/ldflags.sh
@@ -1,5 +1,16 @@
 githash=$(git rev-parse --short HEAD)
 gittag=$(git name-rev --tags --name-only $githash)
+
+if [ "$semverIfJenkins" == "1" ]
+then
+	if [[ $gittag == "jenkins"* ]]
+	then
+	## We've got some bogus Jenkins tag
+	## Get the latest semver-style tag
+		gittag=$(git tag -l "v*" | tail -n 1)
+	fi
+fi
+
 gitbranch=$(git rev-parse --abbrev-ref HEAD)
 now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 VERSION=${VERSION:-$githash}


### PR DESCRIPTION
If the git tag begins with "jenkins", there's a pretty strong chance
that Jenkins is clobbering our git tag. I've added logic that checks for
a new env var, `semverIfJenkins`. If that is set to 1 when ldflags.sh is
called, ldflags.sh will check to see if the git tag begins with
"jenkins", and, if so, it grabs the latest git tag beginning with the
character "v" assuming that is a semver tag.

If semverIfJenkins is set but there is no semver tag, gittag will be
empty string.

Usage:

```
semverIfJenkins=1 source ldflags.sh
```
